### PR TITLE
Handle API key errors

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -33,8 +33,8 @@ Connection_.prototype.buildErrorMessage = function (errors) {
 
   if (errors instanceof Array) {
     message = errors.map(function (error) { return error.message }).join(', ')
-  } else if (errors.hasOwnProperty('detail')) {
-    message = errors.detail
+  } else if (errors.hasOwnProperty('details')) {
+    message = errors.details
   }
 
   return message

--- a/src/connection.js
+++ b/src/connection.js
@@ -29,7 +29,15 @@ Connection_.prototype.fetchQuery = function (query) {
 }
 
 Connection_.prototype.buildErrorMessage = function (errors) {
-  return errors.map(function (error) { return error.message }).join(', ')
+  var message = ''
+
+  if (errors instanceof Array) {
+    message = errors.map(function (error) { return error.message }).join(', ')
+  } else if (errors.hasOwnProperty('detail')) {
+    message = errors.detail
+  }
+
+  return message
 }
 
 Connection_.prototype.handleResponse = function (responseCode, responseBody, queryName) {

--- a/test/connectionTest.js
+++ b/test/connectionTest.js
@@ -76,13 +76,13 @@ describe('error handling', () => {
     expect(logStub).to.have.been.calledWith(sinon.match(expectedLogMessage))
   })
 
-  it('can handle known server errors with detail key', () => {
+  it('can handle known server errors with details key', () => {
     const stub = sandbox.stub(san.UrlFetchApp, '_request')
     const logStub = sandbox.stub(san, 'logError_').returns(null)
 
     const body = {
       errors: {
-        detail: 'Bad authorization header'
+        details: 'Bad authorization header'
       }
     }
 
@@ -130,7 +130,7 @@ describe('error handling', () => {
 
     const body = {
       errors: {
-        detail: 'Internal server error'
+        details: 'Internal server error'
       }
     }
 

--- a/test/connectionTest.js
+++ b/test/connectionTest.js
@@ -42,7 +42,7 @@ describe('headers', () => {
 })
 
 describe('error handling', () => {
-  it('can handle known server errors', () => {
+  it('can handle known server errors with errors array', () => {
     const stub = sandbox.stub(san.UrlFetchApp, '_request')
     const logStub = sandbox.stub(san, 'logError_').returns(null)
 
@@ -71,6 +71,32 @@ describe('error handling', () => {
       responseCode: 400,
       responseBody: JSON.stringify(body)
     }
+
+    expect(() => conn.graphQLQuery('', '')).to.throw(expectedError)
+    expect(logStub).to.have.been.calledWith(sinon.match(expectedLogMessage))
+  })
+
+  it('can handle known server errors with detail key', () => {
+    const stub = sandbox.stub(san.UrlFetchApp, '_request')
+    const logStub = sandbox.stub(san, 'logError_').returns(null)
+
+    const body = {
+      errors: {
+        detail: 'Bad authorization header'
+      }
+    }
+
+    stub.returns({ body: JSON.stringify(body), statusCode: 400 })
+
+    const conn = new san.Connection_()
+
+    const expectedError = 'Server error!'
+    const expectedLogMessage = {
+      message: expectedError + ' ' + 'Bad authorization header',
+      query: '',
+      queryName: '',
+      responseCode: 400,
+      responseBody: JSON.stringify(body) }
 
     expect(() => conn.graphQLQuery('', '')).to.throw(expectedError)
     expect(logStub).to.have.been.calledWith(sinon.match(expectedLogMessage))


### PR DESCRIPTION
Now SANsheets will be able to handle errors in the form of array or object with a "detail" key:

```json
{
  "errors": [
    {"locations": [{ "column": 0, "line": 3 }], "message": "message 1"},
    {"locations": [{ "column": 0, "line": 1 }], "message": "message 2"}
  ]
}
```
```json
{
  "errors": {"detail": "Bad authorization header"}
}
```