### PR TITLE
Handle errors in UI dialogs

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -53,7 +53,7 @@ function addApiKeyDialog_ () {
 
   if (button === ui.Button.OK) {
     var apiClient = new ApiClient_(new Connection_(input))
-    var userPermissions = apiClient.fetchCurrentUserPermissions()
+    var userPermissions = handleErrors_(apiClient.fetchCurrentUserPermissions)()
     var userMessage = addApiKey_(input, userPermissions)
     ui.alert(userMessage)
   }
@@ -75,7 +75,7 @@ function validateApiKeyDialog_ () {
   var apiKey = apiKeyProperty_()
 
   var apiClient = new ApiClient_(new Connection_(apiKey))
-  var userPermissions = apiClient.fetchCurrentUserPermissions()
+  var userPermissions = handleErrors_(apiClient.fetchCurrentUserPermissions)()
   var userMessage = checkApiKeyStillValid_(apiKey, userPermissions)
   ui.alert(userMessage)
 }


### PR DESCRIPTION
Instead of an error:
![Screenshot from 2019-05-27 11-07-36](https://user-images.githubusercontent.com/103871/58407054-93c0ef00-8073-11e9-8934-310d1d65c334.png)

handle the error and display a nice message to the user:
![Screenshot from 2019-05-27 11-07-58](https://user-images.githubusercontent.com/103871/58407095-a89d8280-8073-11e9-9064-1f12781285ce.png)
