### PR TITLE
Fix SAN_PRICE_ABSOLUTE_CHANGE to include full last day

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -397,6 +397,15 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-datetime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/chai-datetime/-/chai-datetime-1.5.0.tgz",
+      "integrity": "sha1-N0LxiwJMdbdqK37uKRZiMkRnWWw=",
+      "dev": true,
+      "requires": {
+        "chai": ">1.9.0"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@google/clasp": "^2.0.1",
     "chai": "^4.2",
+    "chai-datetime": "^1.5.0",
     "date-fns": "^1.30.1",
     "eslint": "^5.14.1",
     "eslint-config-es5": "^0.5.0",

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -39,6 +39,7 @@
     "fetchUserPermissions_": "readonly",
     "API_KEY": "readonly",
     "toUTC_": "readonly",
+    "beginningOfDaytoEndOfDay_": "readonly",
     "prices_": "readonly",
     "priceAbsoluteChange_": "readonly",
     "allProjects_": "readonly",

--- a/src/functions.js
+++ b/src/functions.js
@@ -21,7 +21,9 @@ function prices_ (slug, from, to) {
 function priceAbsoluteChange_ (slug, from, to) {
   assertCanAccessHistoricData_(from)
 
-  var results = getApiClient_().fetchOhlc(slug, from, to)
+  var endOfDay = beginningOfDaytoEndOfDay_(to)
+
+  var results = getApiClient_().fetchOhlc(slug, from, endOfDay)
   assertHasData_(results)
 
   var firstDateResults = results[0]

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -38,3 +38,8 @@ function toUTC_ (date) {
   var timezone = SpreadsheetApp.getActive().getSpreadsheetTimeZone()
   return Utilities.formatDate(new Date(date), timezone, "yyyy-MM-dd'T'HH:mm:ss'Z'")
 }
+
+function beginningOfDaytoEndOfDay_ (date) {
+  var millisInDay = 24 * 60 * 60 * 1000
+  return new Date(date.getTime() + millisInDay - 1000) // remove a second to get 23:59:59
+}

--- a/test/functions/priceAbsoluteChangeTest.js
+++ b/test/functions/priceAbsoluteChangeTest.js
@@ -1,9 +1,30 @@
+/* eslint-disable no-unused-expressions */
+
 require('../helper.js')
 
 describe('priceAbsoluteChange_', () => {
   const slug = 'santiment'
-  const from = '2019-01-01T00:00:00.000Z'
-  const to = '2019-01-03T00:00:00.000Z'
+
+  const from = new Date(2019, 0, 1, 0, 0, 0)
+  const to = new Date(2019, 0, 3, 0, 0, 0)
+
+  beforeEach(() => sandbox.stub(san, 'assertCanAccessHistoricData_').returns(true))
+
+  it('includes the last day of the period', () => {
+    const beginningOfDaytoEndOfDay = sandbox.stub(san, 'beginningOfDaytoEndOfDay_')
+    sandbox.stub(san.ApiClient_.prototype, 'fetchOhlc').returns(
+      [
+        {
+          'openPriceUsd': 100.00,
+          'closePriceUsd': 100.01
+        }
+      ]
+    )
+
+    san.priceAbsoluteChange_(slug, from, to)
+
+    expect(beginningOfDaytoEndOfDay).to.have.been.called
+  })
 
   it('returns the absolute change between last close and first open price', () => {
     sandbox.stub(san.ApiClient_.prototype, 'fetchOhlc').returns(

--- a/test/helper.js
+++ b/test/helper.js
@@ -4,6 +4,7 @@ const sandbox = sinon.createSandbox()
 const chai = require('chai')
 const expect = chai.expect
 chai.use(sinonChai)
+chai.use(require('chai-datetime'))
 
 const gas = require('gas-local')
 const mock = require('../index.js')

--- a/test/utilitiesTest.js
+++ b/test/utilitiesTest.js
@@ -60,3 +60,12 @@ describe('assertCanAccessHistoricData_', () => {
     expect(() => san.assertCanAccessHistoricData_(from)).to.not.throw()
   })
 })
+
+describe('beginningOfDaytoEndOfDay_', () => {
+  it('returns datetime at 23:59:59 for a given beginning of day datetime', () => {
+    const startOfDay = new Date(2019, 0, 1, 0, 0, 0)
+    const endOfDay = new Date(2019, 0, 1, 23, 59, 59)
+
+    expect(san.beginningOfDaytoEndOfDay_(startOfDay)).to.equalTime(endOfDay)
+  })
+})


### PR DESCRIPTION
**Background**
If you request data for:
 `=SAN_PRICE_ABSOLUTE_CHANGE("bitcoin", DATE(2019, 6, 11), DATE(2019, 6, 13))` 

that would make the following call to the API: 
`ohlc(slug: "bitcoin", from: "2019-06-11T00:00:00Z", to: "2019-06-13T00:00:00Z", interval: "1d"` 

which returns: 
```json
{
  "data": {
    "ohlc": [
      {
        "closePriceUsd": 7927.71435114,
        "datetime": "2019-06-11T00:00:00Z",
        "openPriceUsd": 8013.60294392
      },
      {
        "closePriceUsd": 8145.54523047,
        "datetime": "2019-06-12T00:00:00Z",
        "openPriceUsd": 7929.88638575
      },
      {
        "closePriceUsd": 0,
        "datetime": "2019-06-13T00:00:00Z",
        "openPriceUsd": 0
      }
    ]
  }
}
```

Notice the `0`, the function is not usable. The desired behavior is to include the whole day from the end of the interval. Probably this also needs to be fixed in the API itself. 

**After the PR changes**
`ohlc(slug: "bitcoin", from: "2019-06-11T00:00:00Z", to: "2019-06-13T23:59:59Z", interval: "1d"` is sent to the API, and the response is: 
```json
{
  "data": {
    "ohlc": [
      {
        "closePriceUsd": 7927.71435114,
        "datetime": "2019-06-11T00:00:00Z",
        "openPriceUsd": 8013.60294392
      },
      {
        "closePriceUsd": 8145.54523047,
        "datetime": "2019-06-12T00:00:00Z",
        "openPriceUsd": 7929.88638575
      },
      {
        "closePriceUsd": 8230.92383068,
        "datetime": "2019-06-13T00:00:00Z",
        "openPriceUsd": 8156.17436182
      }
    ]
  }
}
```
