### PR TITLE
Add jsdoc comment for SAN_HISTORICAL_BALANCE

### DIFF
--- a/src/sheetFunctions.js
+++ b/src/sheetFunctions.js
@@ -457,6 +457,17 @@ function SAN_DAILY_CLOSING_PRICE (projectSlug, day) {
   return handleErrors_(dailyClosingPrice_)(projectSlug, day)
 }
 
+/**
+ * Returns the historical balance for a given ERC20 or ETH address.
+ * @param {string} projectSlug Name of the asset at sanbase,
+ * which can be found at the end of the URL (eg. the Santiment URL is
+ * https://app.santiment.net/projects/santiment, so the projectSlug would be santiment).
+ * @param {date} from The starting date to fetch the data. Example: DATE(2018, 9, 20)
+ * @param {date} to The ending date to fetch the data. Example: DATE(2018, 9, 21)
+ * @param {string} address ERC20 or ETH address.
+ * @returns {Array} of balances.
+ * @customfunction
+ */
 function SAN_HISTORICAL_BALANCE (projectSlug, from, to, address) {
   return handleErrors_(historicalBalance_)(projectSlug, from, to, address)
 }


### PR DESCRIPTION
Jsdoc is used in Google Apps Script to distinguish the custom functions and render a help tooltip like this:
![Screenshot from 2019-07-29 09-25-45](https://user-images.githubusercontent.com/103871/62026294-4253ee00-b1e3-11e9-8b0f-ee4df297ed7a.png)
 