### PR TITLE
Modify the test for san news

### DIFF
--- a/test/integration/sanNewsTest.js
+++ b/test/integration/sanNewsTest.js
@@ -8,11 +8,17 @@ const {
 const {
   slug,
   ethereumSlug,
-  from,
-  to,
   historicDataFrom,
   historicDataTo
 } = require('../setup.js')
+
+/*
+It is not certain that there would be news
+between the two dates, that's why the dates
+are not dynamically produced
+*/
+const from = new Date(2019, 6, 15, 0, 0, 0)
+const to = new Date(2019, 6, 31, 0, 0, 0)
 
 describe('SAN_NEWS', () => {
   const size = 5


### PR DESCRIPTION
SAN NEWS can return an empty list, because there aren't any results, that way the tests fail. Hence the change in the interval.